### PR TITLE
Kafa migration rabbitmq

### DIFF
--- a/RabbitMQ/Dockerfile
+++ b/RabbitMQ/Dockerfile
@@ -1,0 +1,5 @@
+FROM rabbitmq:3.13.0-management-alpine
+
+COPY rabbitmq.conf /etc/rabbitmq
+
+RUN cat /etc/rabbitmq/rabbitmq.conf

--- a/RabbitMQ/rabbitmq.conf
+++ b/RabbitMQ/rabbitmq.conf
@@ -1,0 +1,4 @@
+default_user = $(RABBITMQ_USER)
+default_pass = $(RABBITMQ_PASSWORD)
+listeners.tcp.default = 5672
+management.tcp.port = 15672

--- a/Scripts/docker-compose.yml
+++ b/Scripts/docker-compose.yml
@@ -60,27 +60,15 @@ services:
       - 5432:5432
     restart: unless-stopped
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+  homeo-rabbit:
+    container_name: homeo-rabbit
+    build: ../RabbitMQ
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
+      RABBITMQ_USER: ${RABBITMQ_USER}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
     ports:
-      - 22181:2181
-
-  kafka:
-    image: confluentinc/cp-kafka:latest
-    ports:
-      - 29092:29092
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-    depends_on:
-      - zookeeper
+      - "5672:5672"
+      - "15672:15672"
 
 volumes:
   homeo-postgres:


### PR DESCRIPTION
Infrastructure migration from kafka to rabbitmq to reduce the size of the docker images